### PR TITLE
Add ControlPanel addon with Pladdon implementation and update dependencies

### DIFF
--- a/src/main/java/world/bentobox/controlpanel/ControlPanelPladdon.java
+++ b/src/main/java/world/bentobox/controlpanel/ControlPanelPladdon.java
@@ -1,0 +1,18 @@
+package world.bentobox.controlpanel;
+
+
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.addons.Pladdon;
+
+public class ControlPanelPladdon extends Pladdon {
+
+    private Addon addon;
+
+    @Override
+    public Addon getAddon() {
+        if (addon == null) {
+            addon = new ControlPanelAddon();
+        }
+        return addon;
+    }
+}

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -1,4 +1,4 @@
-# Name of your addon that wil lbe used in displaying it.
+# Name of your addon that will be used in displaying it.
 name: ControlPanel
 # Addon main class. This class should extend Addon.class
 main: world.bentobox.controlpanel.ControlPanelAddon
@@ -12,14 +12,14 @@ repository: 'BentoBoxWorld/ControlPanel'
 # Must use Material.values() with uppercase.
 icon: 'COMMAND_BLOCK'
 # Minimum BentoBox API version
-api-version: 1.14
+api-version: 3.10.0
 
 # List of addon authors.
 authors:
   - BONNe
 
 # Soft dependencies of current addon.
-softdepend: AcidIsland, BSkyBlock, CaveBlock, SkyGrid, AOneBlock, ItemsAdder
+softdepend: AcidIsland, BSkyBlock, CaveBlock, SkyGrid, AOneBlock, ItemsAdder, Poseidon, Boxed, StrangerRealms
 
 # List of addon permissions
 permissions:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: BentoBox-ControlPanel
+main: world.bentobox.controlpanel.ControlPanelPladdon
+version: ${project.version}${build.number}
+api-version: "1.21"
+
+authors: [tastybento]
+contributors: ["The BentoBoxWorld Community"]
+website: https://bentobox.world
+description: ${project.description}


### PR DESCRIPTION
This pull request introduces the foundational setup for the ControlPanel addon, including its main entry point, plugin metadata, and updated dependencies. The most important changes are grouped below:

### New Addon Initialization

* Added a new `ControlPanelPladdon` class as the main entry point for the addon, implementing the required `Pladdon` interface and providing the `ControlPanelAddon` instance. (`src/main/java/world/bentobox/controlpanel/ControlPanelPladdon.java`)

### Plugin Metadata and Configuration

* Added a new `plugin.yml` file specifying the plugin's name, main class, versioning, API version, authors, contributors, website, and description for proper Bukkit/Spigot registration. (`src/main/resources/plugin.yml`)
* Updated `addon.yml` to require BentoBox API version 3.10.0 (up from 1.14) and expanded the list of soft dependencies to include `Poseidon`, `Boxed`, and `StrangerRealms`. (`src/main/resources/addon.yml`)