### PR TITLE
Add CurseForge publish workflow (publishes the release asset)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: ""           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 # ControlPanel — .github/workflows/publish.yml
-# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
-# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
-# the release asset rather than rebuilding from source, so a dependency-repo outage
-# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
+# Publishes the jar attached to a GitHub release to CurseForge via the
+# shared BentoBoxWorld/.github reusable workflow. Downloads the release asset instead of
+# rebuilding from source. The reusable workflow is pinned to a commit SHA (Sonar
+# githubactions:S7637). workflow_dispatch lets you (re)publish a given version.
 
 name: Publish release to CurseForge
 
@@ -18,10 +18,10 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
+      hangar_slug: ""           # blank = skip Hangar
       curseforge_id: "1514827"
       game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,30 @@
 # ControlPanel — .github/workflows/publish.yml
-# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
+# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
+# the release asset rather than rebuilding from source, so a dependency-repo outage
+# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
 
-name: Publish release
+name: Publish release to CurseForge
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
+        type: string
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
     with:
-      hangar_slug: ""
+      use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
+      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
       curseforge_id: "1514827"
-      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
     secrets:
       HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
       CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` so each GitHub release is published to CurseForge (project id `1514827`) via the shared `BentoBoxWorld/.github` reusable workflow.

- Downloads the jar already attached to the release (`use_release_asset: true`) instead of rebuilding from source, so a third-party dependency-repo outage can't block publishing.
- Game versions: `26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5` (CurseForge auto-drops any it doesn't yet accept).
- Hangar is left blank; set `hangar_slug` to enable it later.
- Requires the `CURSEFORGE_TOKEN` (and optional `HANGAR_API_KEY`) secret to be available to this repo (org-level secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)